### PR TITLE
lmapd: add support for shared library and to skip tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
 
 project(lmapd VERSION 0.4.0 LANGUAGES C)
 
+option(BUILD_SHARED_LIBS "Build the shared library" OFF)
+option(BUILD_TESTS "Build test programs" ON)
+
 set(CMAKE_BUILD_TYPE RelWithDebInfo)
 
 # experimental code coverage stuff...
@@ -22,12 +25,14 @@ endif(CMAKE_COMPILER_IS_GNUCC)
 
 add_subdirectory(doc)
 add_subdirectory(src)
-add_subdirectory(test)
 
 # testing related definitions
-enable_testing()
-add_test(NAME lmap COMMAND check-lmap)
-add_test(NAME lmapd COMMAND check-lmapd)
+if(BUILD_TESTS)
+    add_subdirectory(test)
+    enable_testing()
+    add_test(NAME lmap COMMAND check-lmap)
+    add_test(NAME lmapd COMMAND check-lmapd)
+endif(BUILD_TESTS)
 
 # source packages 'make package_source' or 'make dist'
 set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,5 +35,8 @@ target_link_libraries(lmapctl
 	${LIBXML2_LIBRARIES}
 	${LIBJSONC_LIBRARIES})
 
+if(BUILD_SHARED_LIBS)
+    install(TARGETS lmap LIBRARY DESTINATION lib)
+endif(BUILD_SHARED_LIBS)
 install(TARGETS lmapd DESTINATION bin)
 install(TARGETS lmapctl DESTINATION bin)


### PR DESCRIPTION
Add CMake OPTIONS to skip the tests, and also to enable shared-library
support for the private libimap (which reduces the resource usage on
embedded devices).

By default, continue using static libraries, and enable the tests.

Note: enabling shared library support causes CMake to use dynamic
linking, which results in less FLASH usage for lmapd + lmapctl + liblmap.so
than lmapd + lmapctl when using liblmap.a.