### PR TITLE
Safer action -> schedule queue dataflow

### DIFF
--- a/src/runner.c
+++ b/src/runner.c
@@ -329,6 +329,12 @@ schedule_exec(struct lmapd *lmapd, struct schedule *schedule)
 
     // lmap_dbg("executing schedule '%s'", schedule->name);
     
+    /* avoid leftover data (possibly due to a crash) from
+     * previous runs of an action. */
+    for (act = schedule->actions; act; act = act->next) {
+	(void) lmapd_workspace_action_clean(lmapd, act);
+    }
+
     event_base_gettimeofday_cached(lmapd->base, &t);
     
     switch (schedule->mode) {

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -43,7 +43,12 @@ static const char delimiter = ';';
  * @brief Create a safe filesystem name
  *
  * Creates a safe filesystem name. Unsafe characters are %-encoded if
- * necessary.
+ * necessary.  It ensures the filename does not start with [._] to
+ * avoid creating hidden files, and to give lmapd a private namespace
+ * to work with (anything starting with "_").
+ *
+ * Note: as a side-effect, does not allow filenames to start with a
+ * few other characters, either, and will %-escape them instead.
  *
  * @param name file system name
  * @return pointer to a safe filesystem name (static buffer)
@@ -58,7 +63,7 @@ mksafe(const char *name)
     static char save_name[NAME_MAX];
     
     for (i = 0, j = 0; name[i] && j < NAME_MAX-1; i++) {
-	if (isalnum(name[i]) || strchr(safe, name[i])) {
+	if (isalnum(name[i]) || (i > 0 && strchr(safe, name[i]))) {
 	    save_name[j++] = name[i];
 	} else {
 	    /* %-escape the char if there is enough space left */

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -271,7 +271,7 @@ lmapd_workspace_schedule_clean(struct lmapd *lmapd, struct schedule *schedule)
 	    continue;
 	}
 	if (fstatat(dirfd(dfd), dp->d_name, &st, AT_SYMLINK_NOFOLLOW)
-		|| st.st_mode & S_IFDIR) {
+		|| S_ISDIR(st.st_mode)) {
 	    continue;
 	}
 	if (unlinkat(dirfd(dfd), dp->d_name, 0)) {

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -15,8 +15,9 @@
  * along with lmapd. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #define _POSIX_C_SOURCE 200809L
+#define _GNU_SOURCE 1 /* open(O_DIRECTORY), dirfd() prototype */
 
 #include <assert.h>
 #include <stdlib.h>

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -485,6 +485,7 @@ lmapd_workspace_action_move(struct lmapd *lmapd, struct schedule *schedule,
     const char *newfileformat;
     struct dirent *dp;
     DIR *dfd;
+    struct stat st;
 
     assert(lmapd);
     (void) lmapd;
@@ -509,7 +510,9 @@ lmapd_workspace_action_move(struct lmapd *lmapd, struct schedule *schedule,
     }
 
     while ((dp = readdir(dfd)) != NULL) {
-	if (!strcmp(dp->d_name, ".") || !strcmp(dp->d_name, "..")) {
+	/* we only "move" files, never directories or other inode types */
+	if (fstatat(dirfd(dfd), dp->d_name, &st, AT_SYMLINK_NOFOLLOW)
+		|| !S_ISREG(st.st_mode)) {
 	    continue;
 	}
 	snprintf(oldfilepath, sizeof(oldfilepath), "%s/%s",

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -27,6 +27,8 @@ extern int lmapd_workspace_update(struct lmapd *lmapd);
 
 extern int lmapd_workspace_action_clean(struct lmapd *lmapd, struct action *action);
 extern int lmapd_workspace_action_move(struct lmapd *lmapd, struct schedule *schedule, struct action *action, struct schedule *destination);
+extern int lmapd_workspace_schedule_move(struct lmapd *lmapd, struct schedule *schedule);
+extern int lmapd_workspace_schedule_clean(struct lmapd *lmapd, struct schedule *schedule);
 
 extern int lmapd_workspace_action_open_data(struct schedule *schedule, struct action *action, int flags);
 


### PR DESCRIPTION
This PR addresses issue #13.

The current data flow from an action (in schedule A) to destination(s) in schedule B... is:

*  If an action returns non-zero, its results are destroyed.
*  If an action returns zero, and has destinations, its output is moved to the destination schedule(s) "base directory", regardless of whether that (destination) schedule is already running or not.
*  There is no data life-cycle management implemented to deal with consumed data by an action.

This really gets in the way of implementing resilient reporting of results to a collector. The desired report flow is: render the report, optionally compress it, and if this fails (e.g. storage full), don't remove the source data. After the report is rendered successfully, remove only the source data that is present in that report, and queue the report for transmission. The report is only removed when the transmission succeeds. The render+transmit steps may be implemented atomically, and then it becomes "the source data present in the report must only be removed when the transmission succeeds".

This PR implements the following action -> schedule data-flow:

1. Action output is sent to an "incoming" queue on each schedule (it can continue to be the base directory of the schedule -- unless it is directed to that actions own schedule, in which case it goes to the "processing" queue of the schedule for immediate availability.
2. Data can arrive at the "incoming" queue of a schedule at any time, including while that scheduling is already running. Either advisory locking or "write then rename" strategies must be used to ensure no "live" pair of (data, meta) files exist. This is already true as implemented.
3. When the runner will start processing a schedule, it moves every pair of (meta, data) files to a "processing" queue of that schedule.
4. Actions must consume data only from the "processing" queue of their schedule.
5. If, and only if, every action of a schedule returns a zero status, the "processing" queue is emptied by the runner when the schedule finishes running. If any of the actions return a non-zero status or no action exists, the "processing" queue is left alone (i.e. accumulates data).

Note: if a schedule has no actions, it currently will accumulate input in its storage (because it doesn't actually "run"). This behavior is left unchanged.
