### PR TITLE
lmapctl: report: correct ma-report-result-event-time

### DIFF
--- a/src/json-io.c
+++ b/src/json-io.c
@@ -195,7 +195,7 @@ render_result(struct result *res, json_object *jobj)
     }
     
     if (res->event) {
-	render_leaf_datetime(robj, "event", &res->start);
+	render_leaf_datetime(robj, "event", &res->event);
     }
     
     if (res->start) {

--- a/src/xml-io.c
+++ b/src/xml-io.c
@@ -2479,7 +2479,7 @@ render_result(struct result *res, xmlNodePtr root, xmlNsPtr ns)
     }
     
     if (res->event) {
-	render_leaf_datetime(node, ns, "event", &res->start);
+	render_leaf_datetime(node, ns, "event", &res->event);
     }
     
     if (res->start) {


### PR DESCRIPTION
A typo in the render_report() function caused the start time of an
action to be reported as the ma-report-result-event-time.

This issue is present both in the xml-io.c and json-io.c modules.

CEPTRO.br-issue: MDC-701