### PR TITLE
Miscelaneous fixes and cleanups (respin of #11)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ project(lmapd VERSION 0.4.0 LANGUAGES C)
 option(BUILD_SHARED_LIBS "Build the shared library" OFF)
 option(BUILD_TESTS "Build test programs" ON)
 
-set(CMAKE_BUILD_TYPE RelWithDebInfo)
-
 # experimental code coverage stuff...
 #set(CMAKE_CXX_FLAGS "-g -O0 -Wall -fprofile-arcs -ftest-coverage")
 #set(CMAKE_C_FLAGS "-g -O0 -Wall -W -fprofile-arcs -ftest-coverage")

--- a/src/csv.c
+++ b/src/csv.c
@@ -44,7 +44,7 @@ append(FILE *file, const char delimiter, const char *field)
 {
     int i, need_quote = 0;
     const char quote = '"';
-    
+
     if (! field) {
 	fprintf(file, "\n");
 	return;
@@ -57,7 +57,7 @@ append(FILE *file, const char delimiter, const char *field)
 	    break;
 	}
     }
-    
+
     if (need_quote) {
 	fputc(quote, file);
 	for (i = 0; field[i]; i++) {

--- a/src/data.c
+++ b/src/data.c
@@ -411,7 +411,7 @@ lmap_find_schedule(struct lmap *lmap, const char *name)
  */
 
 struct lmap*
-lmap_new()
+lmap_new(void)
 {
     struct lmap *lmap;
 
@@ -622,7 +622,7 @@ lmap_add_result(struct lmap *lmap, struct result *res)
  */
 
 struct agent*
-lmap_agent_new()
+lmap_agent_new(void)
 {
     struct agent *agent;
 
@@ -774,7 +774,7 @@ lmap_agent_set_report_date(struct agent *agent, const char *value)
  */
 
 struct capability*
-lmap_capability_new()
+lmap_capability_new(void)
 {
     struct capability *capability;
 
@@ -866,7 +866,7 @@ lmap_capability_add_system_tags(struct capability *capability)
  */
 
 struct registry *
-lmap_registry_new()
+lmap_registry_new(void)
 {
     struct registry *registry;
 
@@ -917,7 +917,7 @@ lmap_registry_add_role(struct registry *registry, const char *value)
  */
 
 struct option *
-lmap_option_new()
+lmap_option_new(void)
 {
     struct option *option;
 
@@ -974,7 +974,7 @@ lmap_option_set_value(struct option *option, const char *value)
  */
 
 struct tag *
-lmap_tag_new()
+lmap_tag_new(void)
 {
     struct tag *tag;
 
@@ -1017,7 +1017,7 @@ lmap_tag_set_tag(struct tag *tag, const char *value)
  */
 
 struct supp *
-lmap_supp_new()
+lmap_supp_new(void)
 {
     struct supp *supp;
 
@@ -1125,7 +1125,7 @@ lmap_supp_set_state(struct supp *supp, const char *value)
  */
 
 struct event *
-lmap_event_new()
+lmap_event_new(void)
 {
     struct event *event;
 
@@ -1577,7 +1577,7 @@ lmap_event_calendar_match(struct event *event, time_t *now)
  */
 
 struct task *
-lmap_task_new()
+lmap_task_new(void)
 {
     struct task *task;
 
@@ -1687,7 +1687,7 @@ lmap_task_add_tag(struct task *task, const char *value)
  */
 
 struct schedule *
-lmap_schedule_new()
+lmap_schedule_new(void)
 {
     struct schedule *schedule;
 
@@ -1930,7 +1930,7 @@ lmap_schedule_set_workspace(struct schedule *schedule, const char *value)
  */
 
 struct action *
-lmap_action_new()
+lmap_action_new(void)
 {
     struct action *action;
 
@@ -2134,7 +2134,7 @@ lmap_action_set_workspace(struct action *action, const char *value)
  */
 
 struct lmapd *
-lmapd_new()
+lmapd_new(void)
 {
     struct lmapd *lmapd;
 
@@ -2209,7 +2209,7 @@ lmapd_set_run_path(struct lmapd *lmapd, const char *value)
  */
 
 struct value *
-lmap_value_new()
+lmap_value_new(void)
 {
     struct value *val;
 
@@ -2252,7 +2252,7 @@ lmap_value_set_value(struct value *val, const char *value)
  */
 
 struct row *
-lmap_row_new()
+lmap_row_new(void)
 {
     struct row *row;
 
@@ -2314,7 +2314,7 @@ lmap_row_add_value(struct row *row, struct value *val)
  */
 
 struct table *
-lmap_table_new()
+lmap_table_new(void)
 {
     struct table *tab;
 
@@ -2368,7 +2368,7 @@ lmap_table_add_row(struct table *tab, struct row *row)
  */
 
 struct result *
-lmap_result_new()
+lmap_result_new(void)
 {
     struct result *res;
 

--- a/src/data.c
+++ b/src/data.c
@@ -80,19 +80,19 @@ set_yang_identifier(char **dp, const char *s, const char *func)
 	    lmap_err("illegal yang-identifier value '%s'", s);
 	    return -1;
 	}
-	
+
 	for (i = 0; s[i]; i++) {
 	    if (!isalpha(s[i]) && !isdigit(s[i])
 		&& s[i] != '_' && s[i] != '-' && s[i] != '.') {
 		goto error;
 	    }
 	}
-	
+
 	if (strncasecmp("xml", s, 3) == 0) {
 	    goto error;
 	}
     }
-    
+
     return set_string(dp, s, func);
 }
 #endif
@@ -115,7 +115,7 @@ set_lmap_identifier(char **dp, const char *s, const char *func)
 	    }
 	}
     }
-    
+
     return set_string(dp, s, func);
 }
 
@@ -195,7 +195,7 @@ set_timezoneoffset(int16_t *ip, const char *s)
     int hours, minutes;
 
     len = strlen(s);
-    
+
     if (len == 1 && s[0] == 'Z') {
 	*ip = 0;
 	return 0;
@@ -352,7 +352,7 @@ lmap_find_event(struct lmap *lmap, const char *name)
     if (!lmap || !name) {
 	return NULL;
     }
-    
+
     for (event = lmap->events; event; event = event->next) {
 	if (event->name && strcmp(event->name, name) == 0) {
 	    return event;
@@ -370,7 +370,7 @@ lmap_find_task(struct lmap *lmap, const char *name)
     if (!lmap || !name) {
 	return NULL;
     }
-    
+
     for (task = lmap->tasks; task; task = task->next) {
 	if (task->name && strcmp(task->name, name) == 0) {
 	    return task;
@@ -388,7 +388,7 @@ lmap_find_schedule(struct lmap *lmap, const char *name)
     if (! lmap || !name) {
 	return NULL;
     }
-    
+
     for (schedule = lmap->schedules; schedule; schedule = schedule->next) {
 	if (schedule->name && strcmp(schedule->name, name) == 0) {
 	    return schedule;
@@ -439,31 +439,31 @@ lmap_free(struct lmap *lmap)
 	    lmap_schedule_free(lmap->schedules);
 	    lmap->schedules = next;
 	}
-	
+
 	while (lmap->supps) {
 	    struct supp *next = lmap->supps->next;
 	    lmap_supp_free(lmap->supps);
 	    lmap->supps = next;
 	}
-	
+
 	while (lmap->tasks) {
 	    struct task *next = lmap->tasks->next;
 	    lmap_task_free(lmap->tasks);
 	    lmap->tasks = next;
 	}
-	
+
 	while (lmap->events) {
 	    struct event *next = lmap->events->next;
 	    lmap_event_free(lmap->events);
 	    lmap->events = next;
 	}
-	
+
 	while (lmap->results) {
 	    struct result *next = lmap->results->next;
 	    lmap_result_free(lmap->results);
 	    lmap->results = next;
 	}
-	
+
 	xfree(lmap);
     }
 }
@@ -737,7 +737,7 @@ int
 lmap_agent_set_report_measurement_point(struct agent *agent, const char *value)
 {
     int ret;
-    
+
     ret = set_boolean(&agent->report_measurement_point, value, __FUNCTION__);
     if (ret == 0) {
 	agent->flags |= LMAP_AGENT_FLAG_REPORT_MEASUREMENT_POINT_SET;
@@ -749,7 +749,7 @@ int
 lmap_agent_set_controller_timeout(struct agent *agent, const char *value)
 {
     int ret;
-    
+
     ret = set_uint32(&agent->controller_timeout, value, __FUNCTION__);
     if (ret == 0) {
 	agent->flags |= LMAP_AGENT_FLAG_CONTROLLER_TIMEOUT_SET;
@@ -1096,7 +1096,7 @@ int
 lmap_supp_set_stop_running(struct supp *supp, const char *value)
 {
     int ret;
-    
+
     ret = set_boolean(&supp->stop_running, value, __FUNCTION__);
     if (ret == 0) {
 	supp->flags |= LMAP_SUPP_FLAG_STOP_RUNNING_SET;
@@ -1280,7 +1280,7 @@ int
 lmap_event_set_interval(struct event *event, const char *value)
 {
     int ret;
-    
+
     ret = set_uint32(&event->interval, value, __FUNCTION__);
     if (ret == 0) {
 	if (event->interval < 1) {
@@ -1296,7 +1296,7 @@ int
 lmap_event_set_start(struct event *event, const char *value)
 {
     int ret;
-    
+
     ret = set_dateandtime(&event->start, value, __FUNCTION__);
     if (ret == 0) {
 	event->flags |= LMAP_EVENT_FLAG_START_SET;
@@ -1308,7 +1308,7 @@ int
 lmap_event_set_end(struct event *event, const char *value)
 {
     int ret;
-    
+
     ret = set_dateandtime(&event->end, value, __FUNCTION__);
     if (ret == 0) {
 	event->flags |= LMAP_EVENT_FLAG_END_SET;
@@ -1320,7 +1320,7 @@ int
 lmap_event_set_random_spread(struct event *event, const char *value)
 {
     int ret;
-    
+
     ret = set_uint32(&event->random_spread, value, __FUNCTION__);
     if (ret == 0) {
 	if (event->random_spread >= RAND_MAX) {
@@ -1337,7 +1337,7 @@ int
 lmap_event_set_cycle_interval(struct event *event, const char *value)
 {
     int ret;
-    
+
     ret = set_uint32(&event->cycle_interval, value, __FUNCTION__);
     if (ret == 0) {
 	event->flags |= LMAP_EVENT_FLAG_CYCLE_INTERVAL_SET;
@@ -1349,7 +1349,7 @@ int
 lmap_event_add_month(struct event *event, const char *value)
 {
     int i;
-    
+
     struct {
 	char *name;
 	uint16_t value;
@@ -1408,7 +1408,7 @@ int
 lmap_event_add_day_of_week(struct event *event, const char *value)
 {
     int i;
-    
+
     struct {
 	char *name;
 	uint8_t value;
@@ -1503,7 +1503,7 @@ lmap_event_set_timezone_offset(struct event *event, const char *value)
 	lmap_err("illegal timezone offset value '%s'", value);
 	return -1;
     }
-    
+
     event->flags |= LMAP_EVENT_FLAG_TIMEZONE_OFFSET_SET;
     return 0;
 }
@@ -1513,7 +1513,7 @@ lmap_event_calendar_match(struct event *event, time_t *now)
 {
     struct tm *tm;
     int wday;
-    
+
     if (event->type != LMAP_EVENT_TYPE_CALENDAR) {
 	return -1;
     }
@@ -1529,38 +1529,38 @@ lmap_event_calendar_match(struct event *event, time_t *now)
 	// lmap_dbg("%s: month does not match", event->name);
 	return 0;
     }
-    
+
     if (event->days_of_month != UINT32_MAX
 	&&  !(1 << (tm->tm_mday) & event->days_of_month)) {
 	// lmap_dbg("%s: day of month does not match", event->name);
 	return 0;
     }
-    
+
     /*
      * Weekdays are counted differently, struct tm has the week
      * starting with sunday while our lmap week starts with
      * monday.
      */
-    
+
     wday = (tm->tm_wday == 0) ? 6 : (tm->tm_wday -1);
     if (event->days_of_week != UINT8_MAX
 	&&  !(1 << (wday) & event->days_of_week)) {
 	// lmap_dbg("%s: day of week does not match", event->name);
 	return 0;
     }
-    
+
     if (event->hours != UINT32_MAX
 	&&  !(1 << (tm->tm_hour) & event->hours)) {
 	// lmap_dbg("%s: hour does not match", event->name);
 	return 0;
     }
-	
+
     if (event->minutes != UINT64_MAX
 	&&  !(1ull << (tm->tm_min) & event->minutes)) {
 	// lmap_dbg("%s: minute does not match", event->name);
 	return 0;
     }
-    
+
     if (event->seconds != UINT64_MAX
 	&&  !(1ull << (tm->tm_sec) & event->seconds)) {
 	// lmap_dbg("%s: second does not match", event->name);
@@ -1802,7 +1802,7 @@ lmap_schedule_set_duration(struct schedule *schedule, const char *value)
 	schedule->end = NULL;
 	schedule->flags &= ~LMAP_SCHEDULE_FLAG_END_SET;
     }
-    
+
     ret = set_uint64(&schedule->duration, value, __FUNCTION__);
     if (ret == 0) {
 	schedule->flags |= LMAP_SCHEDULE_FLAG_DURATION_SET;
@@ -2187,7 +2187,7 @@ lmapd_set_queue_path(struct lmapd *lmapd, const char *value)
 	lmap_err("invalid queue path '%s'", value);
 	return -1;
     }
-    
+
     return set_string(&lmapd->queue_path, value, __FUNCTION__);
 }
 
@@ -2200,7 +2200,7 @@ lmapd_set_run_path(struct lmapd *lmapd, const char *value)
 	lmap_err("invalid run path '%s'", value);
 	return -1;
     }
-    
+
     return set_string(&lmapd->run_path, value, __FUNCTION__);
 }
 
@@ -2237,7 +2237,7 @@ lmap_value_valid(struct lmap *lmap, struct value *val)
 	lmap_err("val requires a value");
 	valid = 0;
     }
-    
+
     return valid;
 }
 
@@ -2284,7 +2284,7 @@ lmap_row_valid(struct lmap *lmap, struct row *row)
     for (val = row->values; val; val = val->next) {
 	valid &= lmap_value_valid(lmap, val);
     }
-    
+
     return valid;
 }
 
@@ -2346,7 +2346,7 @@ lmap_table_valid(struct lmap *lmap, struct table *tab)
     for (row = tab->rows; row; row = row->next) {
 	valid &= lmap_row_valid(lmap, row);
     }
-    
+
     return valid;
 }
 
@@ -2416,7 +2416,7 @@ lmap_result_valid(struct lmap *lmap, struct result *res)
     for (tab = res->tables; tab; tab = tab->next) {
 	valid &= lmap_table_valid(lmap, tab);
     }
-    
+
     return valid;
 }
 
@@ -2474,12 +2474,12 @@ lmap_result_set_event_epoch(struct result *res, const char *value)
 {
     uint32_t u;
     int ret;
-    
+
     ret = set_uint32(&u, value, __FUNCTION__);
     if (ret == 0) {
 	res->event = u;
     }
-    
+
     return ret;
 }
 
@@ -2494,12 +2494,12 @@ lmap_result_set_start_epoch(struct result *res, const char *value)
 {
     uint32_t u;
     int ret;
-    
+
     ret = set_uint32(&u, value, __FUNCTION__);
     if (ret == 0) {
 	res->start = u;
     }
-    
+
     return ret;
 }
 
@@ -2534,7 +2534,7 @@ lmap_result_set_status(struct result *res, const char *value)
 {
     int32_t i;
     int ret;
-    
+
     ret = set_int32(&i, value, __FUNCTION__);
     if (ret == 0) {
 	res->status = i;

--- a/src/data.c
+++ b/src/data.c
@@ -2157,79 +2157,25 @@ lmapd_free(struct lmapd *lmapd)
 int
 lmapd_set_config_path(struct lmapd *lmapd, const char *value)
 {
-    int ret;
-    size_t len;
     struct stat sb;
-    char *name = NULL;
 
-    if (stat(value, &sb) == -1) {
-    invalid:
-	lmap_err("invalid config path or file '%s'", value);
-	return -1;
-    }
-
-    if (S_ISREG(sb.st_mode) || S_ISDIR(sb.st_mode)) {
+    if (!stat(value, &sb) && (S_ISREG(sb.st_mode) || S_ISDIR(sb.st_mode)))
 	return set_string(&lmapd->config_path, value, __FUNCTION__);
-    } else {
-	goto invalid;
-    }
 
-    /*
-     * Try to find the configuration file by appending a config file
-     * name to the config path.
-     */
-    
-    len = strlen(value) + strlen(LMAPD_CONFIG_FILE) + 2;
-    name = xcalloc(len, 1, __FUNCTION__);
-    snprintf(name, len, "%s/%s", value, LMAPD_CONFIG_FILE);
-    if (! name || stat(name, &sb) == -1 || ! S_ISREG(sb.st_mode)) {
-	lmap_err("invalid config file '%s'", name);
-	xfree(name);
-	return -1;
-    }
-
-    ret = set_string(&lmapd->config_path, name ? name : value, __FUNCTION__);
-    xfree(name);
-    return ret;
+    lmap_err("invalid config path or file '%s'", value);
+    return -1;
 }
 
 int
 lmapd_set_capability_path(struct lmapd *lmapd, const char *value)
 {
-    int ret;
-    size_t len;
     struct stat sb;
-    char *name = NULL;
 
-    if (stat(value, &sb) == -1) {
-    invalid:
-	lmap_err("invalid capability path or file '%s'", value);
-	return -1;
-    }
-
-    if (S_ISREG(sb.st_mode) || S_ISDIR(sb.st_mode)) {
+    if (!stat(value, &sb) && (S_ISREG(sb.st_mode) || S_ISDIR(sb.st_mode)))
 	return set_string(&lmapd->capability_path, value, __FUNCTION__);
-    } else {
-	goto invalid;
-    }
 
-    /*
-     * Try to find the capability file by appending a capability file
-     * name to the capability path.
-     */
-    
-    len = strlen(value) + strlen(LMAPD_CONFIG_FILE) + 2;
-    name = xcalloc(len, 1, __FUNCTION__);
-    snprintf(name, len, "%s/%s", value, LMAPD_CAPABILITY_FILE);
-    if (! name || stat(name, &sb) == -1 || ! S_ISREG(sb.st_mode)) {
-	lmap_err("invalid capability file '%s'", name);
-	xfree(name);
-	return -1;
-    }
-
-    ret = set_string(&lmapd->capability_path, name ? name : value, __FUNCTION__);
-    xfree(name);
-    return ret;
+    lmap_err("invalid capability path or file '%s'", value);
+    return -1;
 }
 
 int

--- a/src/json-io.c
+++ b/src/json-io.c
@@ -237,21 +237,33 @@ render_result(struct result *res, json_object *jobj)
 char *
 lmap_json_render_report(struct lmap *lmap)
 {
-    const char *report = NULL;
+    char *report = NULL;
     json_object *jobj, *aobj, *robj;
     struct result *res;
+    const char *r1;
 
     assert(lmap);
 
-    jobj = json_object_new_object();
-    robj = json_object_new_object();
+    if (!(jobj = json_object_new_object()))
+	return NULL;
+    if (!(robj = json_object_new_object()))
+	goto err_exit;
+
     json_object_object_add(jobj, LMAPR_JSON_NAMESPACE ":" "report", robj);
     render_agent_report(lmap->agent, robj);
-    aobj = json_object_new_array();
+
+    if (!(aobj = json_object_new_array()))
+	goto err_exit;
     json_object_object_add(robj, "result", aobj);
     for (res = lmap->results; res; res = res->next) {
 	render_result(res, aobj);
     }
-    report = json_object_to_json_string_ext(jobj, JSON_C_TO_STRING_PRETTY);
-    return report ? strdup(report) : NULL;
+
+    r1 = json_object_to_json_string_ext(jobj, JSON_C_TO_STRING_PRETTY);
+    if (r1)
+	report = strdup(r1);
+
+err_exit:
+    json_object_put(jobj);
+    return report;
 }

--- a/src/json-io.c
+++ b/src/json-io.c
@@ -38,7 +38,7 @@ static void
 render_leaf(json_object *jobj, char *name, char *content)
 {
     assert(jobj);
-    
+
     if (name && content) {
 	json_object_object_add(jobj, name, json_object_new_string(content));
     }
@@ -55,7 +55,7 @@ render_leaf_datetime(json_object *jobj, char *name, time_t *tp)
 {
     char buf[32];
     struct tm *tmp;
-    
+
     tmp = localtime(tp);
     strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S%z", tmp);
 
@@ -63,22 +63,22 @@ render_leaf_datetime(json_object *jobj, char *name, time_t *tp)
      * Hack to insert the ':' in the timezone offset since strftime()
      * implementations do not generate this separator.
      */
-    
+
     if (strlen(buf) == 24) {
 	buf[25] = buf[24];
 	buf[24] = buf[23];
 	buf[23] = buf[22];
 	buf[22] = ':';
     }
-    
-    render_leaf(jobj, name, buf); 
+
+    render_leaf(jobj, name, buf);
 }
 
 static void
 render_option(struct option *option, json_object *jobj)
 {
     json_object *robj;
-    
+
     if (! option) {
 	return;
     }
@@ -169,13 +169,13 @@ render_result(struct result *res, json_object *jobj)
     struct option *option;
     struct tag *tag;
     struct table *tab;
-    
+
     robj = json_object_new_object();
     if (! robj) {
 	return;
     }
     json_object_array_add(jobj, robj);
-    
+
     render_leaf(robj, "schedule", res->schedule);
     render_leaf(robj, "action", res->action);
     render_leaf(robj, "task", res->task);
@@ -193,15 +193,15 @@ render_result(struct result *res, json_object *jobj)
 	    json_object_array_add(aobj, json_object_new_string(tag->tag));
 	}
     }
-    
+
     if (res->event) {
 	render_leaf_datetime(robj, "event", &res->start);
     }
-    
+
     if (res->start) {
 	render_leaf_datetime(robj, "start", &res->start);
     }
-    
+
     if (res->end) {
 	render_leaf_datetime(robj, "end", &res->end);
     }

--- a/src/lmapctl.c
+++ b/src/lmapctl.c
@@ -78,7 +78,7 @@ static struct lmapd *lmapd = NULL;
 static int format = LMAP_FORMAT_XML;
 
 static void
-atexit_cb()
+atexit_cb(void)
 {
     if (lmapd) {
 	lmapd_free(lmapd);

--- a/src/lmapctl.c
+++ b/src/lmapctl.c
@@ -52,7 +52,7 @@ static int status_cmd(int argc, char *argv[]);
 static int validate_cmd(int argc, char *argv[]);
 static int version_cmd(int argc, char *argv[]);
 
-static struct 
+static struct
 {
     char *command;
     char *description;
@@ -99,7 +99,7 @@ static void
 usage(FILE *f)
 {
     fprintf(f, "usage: %s [-h] [-q queue] [-c config] [-C dir] [-s status]\n"
-	    "\t-q path to queue directory\n" 
+	    "\t-q path to queue directory\n"
 	    "\t-c path to config directory or file\n"
 	    "\t-r path to run directory (pid file and status file)\n"
 	    "\t-C path in which the program is executed\n"
@@ -180,14 +180,14 @@ render_datetime_long(time_t *tp)
      * Hack to insert the ':' in the timezone offset since strftime()
      * implementations do not generate this separator.
      */
-    
+
     if (strlen(buf) == 24) {
 	buf[25] = buf[24];
 	buf[24] = buf[23];
 	buf[23] = buf[22];
 	buf[22] = ':';
     }
-    
+
     return buf;
 }
 
@@ -196,7 +196,7 @@ static char*
 render_uint32(uint32_t num)
 {
     static char buf[32];
-    
+
     if (num > 1000*1000*1000) {
 	snprintf(buf, sizeof(buf), "%uG", ((num/1000/1000)+500)/1000);
     } else if (num > 1000*1000) {
@@ -228,13 +228,13 @@ read_config(struct lmapd *lmapd)
     if (! lmapd->lmap) {
 	return -1;
     }
-    
+
     if (lmap_xml_parse_config_path(lmapd->lmap, lmapd->config_path)) {
 	lmap_free(lmapd->lmap);
 	lmapd->lmap = NULL;
 	return -1;
     }
-    
+
     return 0;
 }
 
@@ -255,26 +255,26 @@ read_state(struct lmapd *lmapd)
 
     snprintf(statefile, sizeof(statefile), "%s/%s",
 	     lmapd->run_path, LMAPD_STATUS_FILE);
-    
+
     lmapd->lmap = lmap_new();
     if (! lmapd->lmap) {
 	return -1;
     }
-    
+
     if (lmap_xml_parse_state_file(lmapd->lmap, statefile)) {
 	lmap_free(lmapd->lmap);
 	lmapd->lmap = NULL;
 	return -1;
     }
-    
+
     return 0;
 }
 
 static int
-clean_cmd(int argc, char *argv[]) 
+clean_cmd(int argc, char *argv[])
 {
     pid_t pid;
-    
+
     if (argc != 1) {
 	printf("%s: wrong # of args: should be '%s'\n",
 	       LMAPD_LMAPCTL, argv[0]);
@@ -296,7 +296,7 @@ clean_cmd(int argc, char *argv[])
 }
 
 static int
-config_cmd(int argc, char *argv[]) 
+config_cmd(int argc, char *argv[])
 {
     char *xml;
 
@@ -312,7 +312,7 @@ config_cmd(int argc, char *argv[])
     if (! lmap_valid(lmapd->lmap)) {
 	return 1;
     }
-    
+
     xml = lmap_xml_render_config(lmapd->lmap);
     if (! xml) {
 	return 1;
@@ -323,14 +323,14 @@ config_cmd(int argc, char *argv[])
 }
 
 static int
-help_cmd(int argc, char *argv[]) 
+help_cmd(int argc, char *argv[])
 {
     if (argc != 1) {
 	printf("%s: wrong # of args: should be '%s'\n",
 	       LMAPD_LMAPCTL, argv[0]);
 	return 1;
     }
-    
+
     help(stdout);
     return 0;
 }
@@ -339,7 +339,7 @@ static int
 reload_cmd(int argc, char *argv[])
 {
     pid_t pid;
-    
+
     if (argc != 1) {
 	printf("%s: wrong # of args: should be '%s'\n",
 	       LMAPD_LMAPCTL, argv[0]);
@@ -386,7 +386,7 @@ report_cmd(int argc, char *argv[])
      * Setup the paths into the workspaces and then load the results
      * found in the current directory.
      */
-    
+
     lmapd_workspace_init(lmapd);
     if (lmapd_workspace_read_results(lmapd) == -1) {
 	return 1;
@@ -412,7 +412,7 @@ static int
 running_cmd(int argc, char *argv[])
 {
     pid_t pid;
-    
+
     if (argc != 1) {
 	printf("%s: wrong # of args: should be '%s'\n",
 	       LMAPD_LMAPCTL, argv[0]);
@@ -431,7 +431,7 @@ static int
 shutdown_cmd(int argc, char *argv[])
 {
     pid_t pid;
-    
+
     if (argc != 1) {
 	printf("%s: wrong # of args: should be '%s'\n",
 	       LMAPD_LMAPCTL, argv[0]);
@@ -458,7 +458,7 @@ status_cmd(int argc, char *argv[])
     struct lmap *lmap = NULL;
     pid_t pid;
     struct timespec tp = { .tv_sec = 0, .tv_nsec = 87654321 };
-    
+
     if (argc != 1) {
 	printf("%s: wrong # of args: should be '%s'\n",
 	       LMAPD_LMAPCTL, argv[0]);
@@ -545,14 +545,14 @@ status_cmd(int argc, char *argv[])
 		   total_attempts ? schedule->cnt_suppressions*100/total_attempts : 0,
 		   total_attempts ? schedule->cnt_overlaps*100/total_attempts : 0,
 		   schedule->cnt_invocations ? schedule->cnt_failures*100/schedule->cnt_invocations : 0);
-	    
+
 	    printf("%5.5s ", render_storage(schedule->storage));
 
 	    if (schedule->last_invocation) {
 		printf("%8.8s%s", "",
 		       render_datetime_short(&schedule->last_invocation));
 	    }
-	    
+
 	    printf("\n");
 
 	    for (action = schedule->actions; action; action = action->next) {
@@ -572,7 +572,7 @@ status_cmd(int argc, char *argv[])
 		default:
 		    state = "?";
 		}
-		
+
 		total_attempts = action->cnt_invocations
 		    + action->cnt_suppressions + action->cnt_overlaps;
 		printf(" %-14.14s ", action->name ? action->name : "???");
@@ -625,7 +625,7 @@ status_cmd(int argc, char *argv[])
 		state = "?";
 		break;
 	    }
-	    
+
 	    printf("%-15.15s ", supp->name ? supp->name : "???");
 	    printf("%-1s ", state);
 
@@ -636,7 +636,7 @@ status_cmd(int argc, char *argv[])
 }
 
 static int
-validate_cmd(int argc, char *argv[]) 
+validate_cmd(int argc, char *argv[])
 {
     if (argc != 1) {
 	printf("%s: wrong # of args: should be '%s'\n",
@@ -654,7 +654,7 @@ validate_cmd(int argc, char *argv[])
 }
 
 static int
-version_cmd(int argc, char *argv[]) 
+version_cmd(int argc, char *argv[])
 {
     if (argc != 1) {
 	printf("%s: wrong # of args: should be '%s'\n",
@@ -674,7 +674,7 @@ main(int argc, char *argv[])
     char *config_path = NULL;
     char *queue_path = NULL;
     char *run_path = NULL;
-    
+
     while ((opt = getopt(argc, argv, "q:c:r:C:hjx")) != -1) {
 	switch (opt) {
 	case 'q':
@@ -713,9 +713,9 @@ main(int argc, char *argv[])
     if (! lmapd) {
 	exit(EXIT_FAILURE);
     }
-    
+
     atexit(atexit_cb);
-    
+
     if (optind >= argc) {
 	lmap_err("expected command argument after options");
 	exit(EXIT_FAILURE);

--- a/src/lmapd.c
+++ b/src/lmapd.c
@@ -36,7 +36,7 @@
 static struct lmapd *lmapd = NULL;
 
 static void
-atexit_cb()
+atexit_cb(void)
 {
     if (lmapd_pid_check(lmapd)) {
 	lmapd_pid_remove(lmapd);
@@ -73,7 +73,7 @@ usage(FILE *f)
  */
 
 static void
-daemonize()
+daemonize(void)
 {
     int fd;
     pid_t pid;

--- a/src/lmapd.c
+++ b/src/lmapd.c
@@ -41,7 +41,7 @@ atexit_cb()
     if (lmapd_pid_check(lmapd)) {
 	lmapd_pid_remove(lmapd);
     }
-    
+
     if (lmapd) {
 	lmapd_free(lmapd);
     }
@@ -55,7 +55,7 @@ usage(FILE *f)
 	    "\t-n parse config and dump config and exit\n"
 	    "\t-s parse config and dump state and exit\n"
 	    "\t-z clean the workspace before starting\n"
-	    "\t-q path to queue directory\n" 
+	    "\t-q path to queue directory\n"
 	    "\t-c path to config directory or file\n"
 	    "\t-b path to capability directory or file\n"
 	    "\t-r path to run directory (pid file and status file)\n"
@@ -140,14 +140,14 @@ read_config(struct lmapd *lmapd)
     if (! lmapd->lmap) {
 	return -1;
     }
-    
+
     ret = lmap_xml_parse_config_path(lmapd->lmap, lmapd->config_path);
     if (ret != 0) {
 	lmap_free(lmapd->lmap);
 	lmapd->lmap = NULL;
 	return -1;
     }
-    
+
     if (lmapd->lmap->agent) {
 	lmapd->lmap->agent->last_started = time(NULL);
     }
@@ -182,7 +182,7 @@ main(int argc, char *argv[])
     char *queue_path = NULL;
     char *run_path = NULL;
     pid_t pid;
-    
+
     while ((opt = getopt(argc, argv, "fnszq:c:b:r:vh")) != -1) {
 	switch (opt) {
 	case 'f':
@@ -226,11 +226,11 @@ main(int argc, char *argv[])
     if (! lmapd) {
 	exit(EXIT_FAILURE);
     }
-    
+
     atexit(atexit_cb);
-    
+
     openlog("lmapd", LOG_PID | LOG_NDELAY, LOG_DAEMON);
-    
+
     (void) lmapd_set_config_path(lmapd,
 		config_path ? config_path : LMAPD_CONFIG_DIR);
     if (!lmapd->config_path) {
@@ -238,7 +238,7 @@ main(int argc, char *argv[])
     }
     (void) lmapd_set_capability_path(lmapd,
 		capability_path ? capability_path : LMAPD_CAPABILITY_DIR);
-    
+
     if (noop || state) {
 	if (read_config(lmapd) != 0) {
 	    exit(EXIT_FAILURE);
@@ -290,7 +290,7 @@ main(int argc, char *argv[])
      * same time. Well, perhaps that is even possible after the power
      * outage? I will fix it later when the power is back. ;-)
      */
-    
+
     srand(time(NULL));
 
     pid = lmapd_pid_read(lmapd);
@@ -312,7 +312,7 @@ main(int argc, char *argv[])
 
 	(void) lmapd_workspace_init(lmapd);
 	ret = lmapd_run(lmapd);
-	
+
 	/*
 	 * Sleep one second just in case we get into a failure loop so
 	 * as to avoid getting into a crazy tight loop.

--- a/src/lmapd.h.in
+++ b/src/lmapd.h.in
@@ -28,8 +28,6 @@
 #define LMAPD_QUEUE_DIR		"@CMAKE_INSTALL_PREFIX@/var/spool/lmapd/queue"
 #define LMAPD_RUN_DIR		"@CMAKE_INSTALL_PREFIX@/var/run"
 
-#define LMAPD_CONFIG_FILE	"lmapd-config.xml"
-#define LMAPD_CAPABILITY_FILE	"lmapd-capabilities.xml"
 #define LMAPD_STATUS_FILE	"lmapd-state.xml"
 #define LMAPD_PID_FILE		"lmapd.pid"
 

--- a/src/pidfile.c
+++ b/src/pidfile.c
@@ -46,7 +46,7 @@ lmapd_pid_read(struct lmapd *lmapd)
 
     snprintf(pidfile, sizeof(pidfile),
 	     "%s/%s", lmapd->run_path, LMAPD_PID_FILE);
-    
+
     if ((f = fopen(pidfile, "r")) == NULL) {
 	return 0;
     }
@@ -55,7 +55,7 @@ lmapd_pid_read(struct lmapd *lmapd)
 	fclose(f);
 	return 0;
     }
-    
+
     fclose(f);
     return pid;
 }
@@ -105,7 +105,7 @@ lmapd_pid_write(struct lmapd *lmapd)
 
     snprintf(pidfile, sizeof(pidfile),
 	     "%s/%s", lmapd->run_path, LMAPD_PID_FILE);
-    
+
     if ((f = fopen(pidfile, "w+")) == NULL) {
 	lmap_err("failed to create pid file '%s'", pidfile);
 	return -1;
@@ -117,7 +117,7 @@ lmapd_pid_write(struct lmapd *lmapd)
 	fclose(f);
 	return -1;
     }
-    
+
     fflush(f);
     fclose(f);
     return 0;

--- a/src/pidfile.c
+++ b/src/pidfile.c
@@ -90,7 +90,7 @@ lmapd_pid_check(struct lmapd *lmapd)
  * @brief Writes current pid into the pidfile
  *
  * Function to write the current process identifier (pid) into a
- * pidfile. File is locked using flock
+ * pidfile.
  *
  * @param lmapd pointer to struct lmapd
  * @return 0 on success, -1 on erorr

--- a/src/pidfile.c
+++ b/src/pidfile.c
@@ -31,7 +31,8 @@
  * @brief Reads the PID stored in the pidfile
  *
  * Function to read the process identifier (PID) stored in the
- * pidfile.
+ * pidfile.  We do a simple check to see if the process is alive,
+ * and return 0 if it isn't.  But it could be any process.
  *
  * @param lmapd pointer to struct lmapd
  * @return valid PID on success, 0 on error
@@ -57,7 +58,7 @@ lmapd_pid_read(struct lmapd *lmapd)
     }
 
     fclose(f);
-    return pid;
+    return (pid > 0 && !(kill(pid, 0) == -1 && errno == ESRCH)) ? pid : 0;
 }
 
 /**

--- a/src/runner.c
+++ b/src/runner.c
@@ -78,7 +78,7 @@ rand_interval(unsigned int min, unsigned int max)
     do {
 	r = rand();
     } while (r >= limit);
-    
+
     return min + (r / buckets);
 }
 
@@ -98,7 +98,7 @@ find_action_by_pid(struct lmap *lmap, pid_t pid)
 {
     struct schedule *sched;
     struct action *act;
-    
+
     assert(lmap);
 
     for (sched = lmap->schedules; sched; sched = sched->next) {
@@ -117,7 +117,7 @@ find_schedule_by_pid(struct lmap *lmap, pid_t pid)
 {
     struct schedule *sched;
     struct action *act;
-    
+
     assert(lmap);
 
     for (sched = lmap->schedules; sched; sched = sched->next) {
@@ -192,7 +192,7 @@ action_exec(struct lmapd *lmapd, struct schedule *schedule, struct action *actio
 
     {
 	struct task *tp = NULL;
-	
+
 	if (lmapd->lmap->capabilities) {
 	    for (tp = lmapd->lmap->capabilities->tasks; tp; tp = tp->next) {
 		if (tp->program && strcmp(task->program, tp->program) == 0) {
@@ -205,7 +205,7 @@ action_exec(struct lmapd *lmapd, struct schedule *schedule, struct action *actio
 	    return -1;
 	}
     }
-    
+
     if (action->pid) {
 	lmap_wrn("action '%s' still running (pid %d) - skipping",
 		 action->name, action->pid);
@@ -220,7 +220,7 @@ action_exec(struct lmapd *lmapd, struct schedule *schedule, struct action *actio
      * elements in argv is on some systems a runtime parameter.
      * Perhaps we should dynamically allocate an argv?
      */
-    
+
     i = 0;
     argv[i] = task->program;
     for (option = task->options; option; option = option->next) {
@@ -290,7 +290,7 @@ action_exec(struct lmapd *lmapd, struct schedule *schedule, struct action *actio
     if (lmapd_workspace_action_meta_add_start(schedule, action, task)) {
 	exit(EXIT_FAILURE);
     }
-    
+
     /*
      * Setup redirection. Data goes into .data files.
      */
@@ -327,9 +327,9 @@ schedule_exec(struct lmapd *lmapd, struct schedule *schedule)
     }
 
     // lmap_dbg("executing schedule '%s'", schedule->name);
-    
+
     event_base_gettimeofday_cached(lmapd->base, &t);
-    
+
     switch (schedule->mode) {
     case LMAP_SCHEDULE_EXEC_MODE_SEQUENTIAL:
 	schedule->last_invocation = t.tv_sec;
@@ -430,7 +430,7 @@ suppression_start(struct lmapd *lmapd, struct supp *supp)
 	    if (schedule->flags & LMAP_SCHEDULE_FLAG_STOP_RUNNING) {
 		action_kill(lmapd, action);
 	    }
-	
+
 	    if (big_tag_match(supp->match, action->suppression_tags)) {
 		// lmap_dbg("suppressing %s", action->name);
 		if (action->state == LMAP_ACTION_STATE_ENABLED) {
@@ -472,7 +472,7 @@ suppression_end(struct lmapd *lmapd, struct supp *supp)
 	if (schedule->state == LMAP_SCHEDULE_STATE_DISABLED) {
 	    continue;
 	}
-	
+
 	if (big_tag_match(supp->match, schedule->suppression_tags)) {
 	    // lmap_dbg("unsuppressing %s", schedule->name);
 	    if (schedule->cnt_active_suppressions) {
@@ -484,7 +484,7 @@ suppression_end(struct lmapd *lmapd, struct supp *supp)
 		}
 	    }
 	}
-	
+
 	for (action = schedule->actions; action; action = action->next) {
 	    if (action->state == LMAP_ACTION_STATE_DISABLED) {
 		continue;
@@ -533,7 +533,7 @@ lmapd_cleanup(struct lmapd *lmapd)
     if (! lmap) {
 	return;
     }
-    
+
     event_base_gettimeofday_cached(lmapd->base, &t);
 
     while (1) {
@@ -650,7 +650,7 @@ static void
 execute_cb(struct lmapd *lmapd, struct event *event)
 {
     struct schedule *sched;
-    
+
     assert(lmapd && event);
 
     if (! lmapd->lmap) {
@@ -658,11 +658,11 @@ execute_cb(struct lmapd *lmapd, struct event *event)
     }
 
     for (sched = lmapd->lmap->schedules; sched; sched = sched->next) {
-	
+
 	if (sched->state == LMAP_SCHEDULE_STATE_DISABLED) {
 	    goto next;
 	}
-	
+
 	if (! sched->name) {
 	    lmap_err("disabling unnamed schedule");
 	    sched->state = LMAP_SCHEDULE_STATE_DISABLED;
@@ -687,7 +687,7 @@ execute_cb(struct lmapd *lmapd, struct event *event)
 		event_base_gettimeofday_cached(lmapd->base, &t);
 		sched->cycle_number = (t.tv_sec / event->cycle_interval) * event->cycle_interval;
 	    }
-	    
+
 	    schedule_exec(lmapd, sched);
 	    if (event->type == LMAP_EVENT_TYPE_ONE_OFF
 		|| event->type == LMAP_EVENT_TYPE_IMMEDIATE
@@ -718,25 +718,25 @@ static void
 suppress_cb(struct lmapd *lmapd, struct event *event)
 {
     struct supp *supp;
-    
+
     assert(lmapd && event);
-    
+
     if (! lmapd->lmap) {
 	return;
     }
-    
+
     for (supp = lmapd->lmap->supps; supp; supp = supp->next) {
-	
+
 	if (supp->state == LMAP_SUPP_STATE_DISABLED) {
 	    continue;
 	}
-	
+
 	if (! supp->name) {
 	    lmap_err("disabling unnamed suppression");
 	    supp->state = LMAP_SUPP_STATE_DISABLED;
  	    continue;
 	}
-	
+
  	if (supp->start && !strcmp(supp->start, event->name)) {
 	    if (supp->state == LMAP_SUPP_STATE_ENABLED) {
 		suppression_start(lmapd, supp);
@@ -745,11 +745,11 @@ suppress_cb(struct lmapd *lmapd, struct event *event)
 			 supp->name);
 	    }
 	}
-	
+
 	if (supp->end && !strcmp(supp->end, event->name)) {
 	    if (supp->state == LMAP_SUPP_STATE_ACTIVE) {
 		suppression_end(lmapd, supp);
-	    } else 
+	    } else
 		lmap_wrn("suppression '%s' not active - skipping",
 			 supp->name);
 	}
@@ -779,7 +779,7 @@ fire_cb(evutil_socket_t fd, short events, void *context)
 
     suppress_cb(event->lmapd, event);
     execute_cb(event->lmapd, event);
-    
+
     event_free(event->fire_event);
     event->fire_event = NULL;
 }
@@ -818,7 +818,7 @@ trigger_calendar_cb(evutil_socket_t fd, short events, void *context)
     struct timeval tv = { .tv_sec = 0, .tv_usec = 0 };
     struct timeval t;
     int match;
-    
+
     (void) fd;
     (void) events;
 
@@ -842,16 +842,16 @@ trigger_calendar_cb(evutil_socket_t fd, short events, void *context)
 	event->trigger_event = NULL;
 	return;
     }
-    
+
     if (match == 0) {
 	tv.tv_sec = 1;
 	event_add(event->trigger_event, &tv);
 	return;
     }
-    
+
     add_random_spread(event, &tv);
     event_gaga(event, &event->fire_event, EV_TIMEOUT, fire_cb, &tv);
-    
+
     tv.tv_sec = match;
     event_add(event->trigger_event, &tv);
 }
@@ -922,11 +922,11 @@ lmapd_run(struct lmapd *lmapd)
 	lmap_err("failed to initialize event base - exiting...");
 	return -1;
     }
-    
+
     /*
      * Register all event callbacks...
      */
-    
+
     for (i = 0; tab[i].name; i++) {
 	if (tab[i].signum) {
 	    tab[i].event = evsignal_new(lmapd->base,
@@ -957,7 +957,7 @@ lmapd_run(struct lmapd *lmapd)
 		struct schedule *sched;
 		struct supp *supp;
 		int used = 0;
-		
+
 		for (sched = lmapd->lmap->schedules; !used && sched; sched = sched->next) {
 		    if (sched->start && ! strcmp(sched->start, event->name)) {
 			used = 1;
@@ -966,7 +966,7 @@ lmapd_run(struct lmapd *lmapd)
 			used = 1;
 		    }
 		}
-		
+
 		for (supp = lmapd->lmap->supps; !used && supp; supp = supp->next) {
 		    if (supp->start && ! strcmp(supp->start, event->name)) {
 			used = 1;
@@ -980,7 +980,7 @@ lmapd_run(struct lmapd *lmapd)
 		    continue;
 		}
 	    }
-	    
+
 	    event->lmapd = lmapd;	/* this avoids a new data structure */
 	    switch (event->type) {
 	    case LMAP_EVENT_TYPE_PERIODIC:
@@ -1020,20 +1020,20 @@ lmapd_run(struct lmapd *lmapd)
 		add_random_spread(event, &tv);
 		event_gaga(event, &event->fire_event, EV_TIMEOUT, fire_cb, &tv);
 		break;
-		
+
 	    case LMAP_EVENT_TYPE_STARTUP:
 	    case LMAP_EVENT_TYPE_IMMEDIATE:
 		add_random_spread(event, &tv);
 		event_gaga(event, &event->fire_event, EV_TIMEOUT, fire_cb, &tv);
 		break;
-		
+
 	    default:
 		lmap_wrn("ignoring event '%s' (not implemented)", event->name);
 		break;
 	    }
 	}
     }
-    
+
     lmap_dbg("event loop starting");
     ret = event_base_dispatch(lmapd->base);
     if (ret != 0) {
@@ -1062,7 +1062,7 @@ lmapd_run(struct lmapd *lmapd)
 	    }
 	}
     }
-    
+
     for (i = 0; tab[i].name; i++) {
 	if (tab[i].event) {
 	    event_free(tab[i].event);
@@ -1074,12 +1074,12 @@ lmapd_run(struct lmapd *lmapd)
      * Cleanup the lmap data model but keep the lmapd daemon state (in
      * case we do a restart).
      */
-    
+
     if (lmapd->lmap) {
 	lmap_free(lmapd->lmap);
 	lmapd->lmap = NULL;
     }
-    
+
     return (ret == 0) ? 0 : -1;
 }
 
@@ -1093,7 +1093,7 @@ lmapd_killall(struct lmapd *lmapd)
     if (! lmapd->lmap) {
 	return;
     }
-    
+
     for (sched = lmapd->lmap->schedules; sched; sched = sched->next) {
 	schedule_kill(lmapd, sched);
     }

--- a/src/runner.c
+++ b/src/runner.c
@@ -1083,7 +1083,7 @@ lmapd_run(struct lmapd *lmapd)
     return (ret == 0) ? 0 : -1;
 }
 
-void
+static void
 lmapd_killall(struct lmapd *lmapd)
 {
     struct schedule *sched;

--- a/src/signals.c
+++ b/src/signals.c
@@ -99,7 +99,7 @@ lmapd_sighub_cb(evutil_socket_t sig, short events, void *context)
     (void) events;
 
     assert(lmapd);
-    lmapd_restart(lmapd); 
+    lmapd_restart(lmapd);
 }
 
 /**
@@ -145,7 +145,7 @@ lmapd_sigusr1_cb(evutil_socket_t sig, short events, void *context)
     char *xml = NULL;
     char filename[PATH_MAX];
     struct lmapd *lmapd = (struct lmapd *) context;
-    
+
     (void) sig;
     (void) events;
 
@@ -196,7 +196,7 @@ void
 lmapd_sigusr2_cb(evutil_socket_t sig, short events, void *context)
 {
     struct lmapd *lmapd = (struct lmapd *) context;
-    
+
     (void) sig;
     (void) events;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -53,7 +53,7 @@ void lmap_set_log_handler(lmap_log_handler handler)
 void lmap_vlog_default(int level, const char *func, const char *format, va_list args)
 {
     char *level_name = NULL;
-    
+
     if (isatty(STDERR_FILENO)) {
 	fprintf(stderr, "lmapd[%d]: ", getpid());
 	switch (level) {
@@ -96,7 +96,7 @@ void lmap_vlog_default(int level, const char *func, const char *format, va_list 
 void lmap_log(int level, const char *func, const char *format, ...)
 {
     va_list args;
-    
+
     va_start(args, format);
     lmap_vlog(level, func, format, args);
     va_end(args);

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -56,7 +56,7 @@ mksafe(const char *name)
     const char safe[] = "-.,_";
     const char hex[] = "0123456789ABCDEF";
     static char save_name[NAME_MAX];
-    
+
     for (i = 0, j = 0; name[i] && j < NAME_MAX-1; i++) {
 	if (isalnum(name[i]) || strchr(safe, name[i])) {
 	    save_name[j++] = name[i];
@@ -94,7 +94,7 @@ remove_cb(const char *fpath, const struct stat *sb,
     (void) sb;
     (void) typeflag;
     (void) ftwbuf;
-    
+
     if (remove(fpath)) {
 	lmap_err("cannot remove %s", fpath);
 	/* we continue to remove the rest */
@@ -181,7 +181,7 @@ lmapd_workspace_clean(struct lmapd *lmapd)
 	lmap_err("failed to open queue directory '%s'", lmapd->queue_path);
 	return -1;
     }
-    
+
     while ((dp = readdir(dfd)) != NULL) {
 	if (!strcmp(dp->d_name, ".") || !strcmp(dp->d_name, "..")) {
 	    continue;
@@ -345,7 +345,7 @@ lmapd_workspace_init(struct lmapd *lmapd)
     struct schedule *sched;
     struct action *act;
     char filepath[PATH_MAX];
-    
+
     assert(lmapd);
 
     if (!lmapd->lmap || !lmapd->queue_path) {
@@ -390,7 +390,7 @@ lmapd_workspace_action_meta_add_start(struct schedule *schedule, struct action *
     char buf[128];
     struct option *option;
     struct tag *tag;
-    
+
     assert(action && action->name && action->workspace);
 
     fd = lmapd_workspace_action_open_meta(schedule, action,
@@ -405,7 +405,7 @@ lmapd_workspace_action_meta_add_start(struct schedule *schedule, struct action *
 	(void) close(fd);
 	return -1;
     }
-    
+
     snprintf(buf, sizeof(buf), "%s version %d.%d.%d", LMAPD_LMAPD,
 	     LMAP_VERSION_MAJOR, LMAP_VERSION_MINOR, LMAP_VERSION_PATCH);
     csv_append_key_value(f, delimiter, "magic", buf);
@@ -454,7 +454,7 @@ lmapd_workspace_action_meta_add_end(struct schedule *schedule, struct action *ac
     char buf[128];
 
     assert(action && action->name && action->workspace);
-    
+
     fd = lmapd_workspace_action_open_meta(schedule, action,
 					  O_WRONLY | O_APPEND);
     if (fd == -1) {
@@ -466,7 +466,7 @@ lmapd_workspace_action_meta_add_end(struct schedule *schedule, struct action *ac
 	(void) close(fd);
 	return -1;
     }
-    
+
     snprintf(buf, sizeof(buf), "%lu", action->last_completion);
     csv_append_key_value(f, delimiter, "end", buf);
     snprintf(buf, sizeof(buf), "%d", action->last_status);

--- a/src/xml-io.c
+++ b/src/xml-io.c
@@ -2054,16 +2054,16 @@ render_action(struct action *action, xmlNodePtr root, xmlNsPtr ns, int what)
     if (what & RENDER_CONFIG_FALSE) {
 	char *state = NULL;
 	switch (action->state) {
-	case LMAP_SCHEDULE_STATE_ENABLED:
+	case LMAP_ACTION_STATE_ENABLED:
 	    state = "enabled";
 	    break;
-	case LMAP_SCHEDULE_STATE_DISABLED:
+	case LMAP_ACTION_STATE_DISABLED:
 	    state = "disabled";
 	    break;
-	case LMAP_SCHEDULE_STATE_RUNNING:
+	case LMAP_ACTION_STATE_RUNNING:
 	    state = "running";
 	    break;
-	case LMAP_SCHEDULE_STATE_SUPPRESSED:
+	case LMAP_ACTION_STATE_SUPPRESSED:
 	    state = "suppressed";
 	    break;
 	}

--- a/src/xml-io.c
+++ b/src/xml-io.c
@@ -58,9 +58,9 @@ parse_agent(struct lmap *lmap, xmlXPathContextPtr ctx, int what)
 {
     int i, j;
     xmlXPathObjectPtr result;
-    
+
     const char *xpath = "//lmapc:lmap/lmapc:agent/lmapc:*";
-    
+
     struct {
 	char *name;
 	int flags;
@@ -92,15 +92,15 @@ parse_agent(struct lmap *lmap, xmlXPathContextPtr ctx, int what)
 	  .func = lmap_agent_set_last_started },
 	{ .name = NULL, .flags = 0, .func = NULL }
     };
-    
+
     assert(lmap);
-    
+
     result = xmlXPathEvalExpression(BAD_CAST xpath, ctx);
     if (! result) {
 	lmap_err("error in xpath expression '%s'", xpath);
 	return -1;
     }
-    
+
     if (!result->nodesetval || !result->nodesetval->nodeNr) {
 	xmlXPathFreeObject(result);
 	return 0;
@@ -113,10 +113,10 @@ parse_agent(struct lmap *lmap, xmlXPathContextPtr ctx, int what)
 	    return -1;
 	}
     }
-    
+
     for (i = 0; result->nodesetval && i < result->nodesetval->nodeNr; i++) {
 	xmlNodePtr node = result->nodesetval->nodeTab[i];
-	
+
 	for (j = 0; tab[j].name; j++) {
 	    if ((tab[j].flags & YANG_KEY)
 		|| (what & PARSE_CONFIG_TRUE && tab[j].flags & YANG_CONFIG_TRUE)
@@ -136,7 +136,7 @@ parse_agent(struct lmap *lmap, xmlXPathContextPtr ctx, int what)
 	}
     }
     xmlXPathFreeObject(result);
-    
+
     return 0;
 }
 
@@ -217,7 +217,7 @@ parse_suppressions(struct lmap *lmap, xmlXPathContextPtr ctx, int what)
     int i;
     xmlXPathObjectPtr result;
     struct supp *supp;
-    
+
     const char *xpath = "//lmapc:lmap/lmapc:suppressions/lmapc:suppression";
 
     assert(lmap);
@@ -428,7 +428,7 @@ parse_tasks(struct lmap *lmap, xmlXPathContextPtr ctx, int what)
     int i;
     xmlXPathObjectPtr result;
     struct task *task;
-    
+
     const char *xpath = "//lmapc:lmap/lmapc:tasks/lmapc:task";
 
     assert(lmap);
@@ -524,7 +524,7 @@ parse_capability_tasks(struct lmap *lmap, xmlXPathContextPtr ctx, int what)
     int i;
     xmlXPathObjectPtr result;
     struct task *task;
-    
+
     const char *xpath = "//lmapc:lmap/lmapc:capabilities/lmapc:tasks/lmapc:task";
 
     assert(lmap);
@@ -542,7 +542,7 @@ parse_capability_tasks(struct lmap *lmap, xmlXPathContextPtr ctx, int what)
 	    return -1;
 	}
     }
-    
+
     for (i = 0; result->nodesetval && i < result->nodesetval->nodeNr; i++) {
 	task = parse_capability_task(result->nodesetval->nodeTab[i], what);
 	if (task) {
@@ -565,9 +565,9 @@ parse_capabilities(struct lmap *lmap, xmlXPathContextPtr ctx, int what)
 {
     int i, j;
     xmlXPathObjectPtr result;
-    
+
     const char *xpath = "//lmapc:lmap/lmapc:capabilities/lmapc:*";
-    
+
     struct {
 	char *name;
 	int flags;
@@ -581,9 +581,9 @@ parse_capabilities(struct lmap *lmap, xmlXPathContextPtr ctx, int what)
 	  .func = lmap_capability_add_tag },
 	{ .name = NULL, .flags = 0, .func = NULL }
     };
-    
+
     assert(lmap);
-    
+
     result = xmlXPathEvalExpression(BAD_CAST xpath, ctx);
     if (! result) {
 	lmap_err("error in xpath expression '%s'", xpath);
@@ -602,7 +602,7 @@ parse_capabilities(struct lmap *lmap, xmlXPathContextPtr ctx, int what)
 	    return -1;
 	}
     }
-    
+
     for (i = 0; result->nodesetval && i < result->nodesetval->nodeNr; i++) {
 	xmlNodePtr node = result->nodesetval->nodeTab[i];
 
@@ -628,7 +628,7 @@ parse_capabilities(struct lmap *lmap, xmlXPathContextPtr ctx, int what)
 	}
     }
     xmlXPathFreeObject(result);
-    
+
     return 0;
 }
 
@@ -657,9 +657,9 @@ parse_periodic(struct event *event, xmlNodePtr period_node, int what)
 
     for (node = xmlFirstElementChild(period_node);
 	 node; node = xmlNextElementSibling(node)) {
-	
+
 	if (node->ns != period_node->ns) continue;
-	
+
 	for (j = 0; tab[j].name; j++) {
 	    if ((tab[j].flags & YANG_KEY)
 		|| (what & PARSE_CONFIG_TRUE && tab[j].flags & YANG_CONFIG_TRUE)
@@ -723,9 +723,9 @@ parse_calendar(struct event *event, xmlNodePtr calendar_node, int what)
 
     for (node = xmlFirstElementChild(calendar_node);
 	 node; node = xmlNextElementSibling(node)) {
-	
+
 	if (node->ns != calendar_node->ns) continue;
-	
+
 	for (j = 0; tab[j].name; j++) {
 	    if ((tab[j].flags & YANG_KEY)
 		|| (what & PARSE_CONFIG_TRUE && tab[j].flags & YANG_CONFIG_TRUE)
@@ -765,9 +765,9 @@ parse_one_off(struct event *event, xmlNodePtr one_off_node, int what)
 
     for (node = xmlFirstElementChild(one_off_node);
 	 node; node = xmlNextElementSibling(node)) {
-	
+
 	if (node->ns != one_off_node->ns) continue;
-	
+
 	for (j = 0; tab[j].name; j++) {
 	    if (!xmlStrcmp(node->name, BAD_CAST tab[j].name)) {
 		xmlChar *content = xmlNodeGetContent(node);
@@ -844,12 +844,12 @@ parse_event(xmlNodePtr event_node, int what)
     if (! event) {
 	return NULL;
     }
-    
+
     for (node = xmlFirstElementChild(event_node);
 	 node; node = xmlNextElementSibling(node)) {
-	
+
 	if (node->ns != event_node->ns) continue;
-	
+
 	for (j = 0; tab[j].name; j++) {
 	    if ((tab[j].flags & YANG_KEY)
 		|| (what & PARSE_CONFIG_TRUE && tab[j].flags & YANG_CONFIG_TRUE)
@@ -891,7 +891,7 @@ parse_events(struct lmap *lmap, xmlXPathContextPtr ctx, int what)
     int i;
     xmlXPathObjectPtr result;
     struct event *event;
-    
+
     const char *xpath = "//lmapc:lmap/lmapc:events/lmapc:event";
 
     assert(lmap);
@@ -1081,12 +1081,12 @@ parse_schedule(xmlNodePtr schedule_node, int what)
     if (! schedule) {
 	return NULL;
     }
-    
+
     for (node = xmlFirstElementChild(schedule_node);
 	 node; node = xmlNextElementSibling(node)) {
-	
+
 	if (node->ns != schedule_node->ns) continue;
-	
+
 	if (!xmlStrcmp(node->name, BAD_CAST "action")) {
 	    struct action *action = parse_action(node, what);
 	    lmap_schedule_add_action(schedule, action);
@@ -1127,7 +1127,7 @@ parse_schedules(struct lmap *lmap, xmlXPathContextPtr ctx, int what)
     int i;
     xmlXPathObjectPtr result;
     struct schedule *schedule;
-    
+
     const char *xpath = "//lmapc:lmap/lmapc:schedules/lmapc:schedule";
 
     assert(lmap);
@@ -1212,7 +1212,7 @@ lmap_xml_parse_config_path(struct lmap *lmap, const char *path)
     char filepath[PATH_MAX];
     struct dirent *dp;
     DIR *dfd;
-    
+
     assert(path);
 
     dfd = opendir(path);
@@ -1240,7 +1240,7 @@ lmap_xml_parse_config_path(struct lmap *lmap, const char *path)
 	}
     }
     (void) closedir(dfd);
-    
+
     return ret;
 }
 
@@ -1249,9 +1249,9 @@ lmap_xml_parse_config_file(struct lmap *lmap, const char *file)
 {
     int ret;
     xmlDocPtr doc = NULL;
-    
+
     assert(file);
-    
+
     doc = xmlParseFile(file);
     if (! doc) {
 	lmap_err("cannot parse config file '%s'", file);
@@ -1274,7 +1274,7 @@ lmap_xml_parse_config_string(struct lmap *lmap, const char *string)
 {
     int ret;
     xmlDocPtr doc = NULL;
-    
+
     assert(string);
 
     doc = xmlParseMemory(string, strlen(string));
@@ -1307,7 +1307,7 @@ lmap_xml_parse_state_path(struct lmap *lmap, const char *path)
     char filepath[PATH_MAX];
     struct dirent *dp;
     DIR *dfd;
-    
+
     assert(path);
 
     dfd = opendir(path);
@@ -1335,7 +1335,7 @@ lmap_xml_parse_state_path(struct lmap *lmap, const char *path)
 	}
     }
     (void) closedir(dfd);
-    
+
     return ret;
 }
 
@@ -1344,9 +1344,9 @@ lmap_xml_parse_state_file(struct lmap *lmap, const char *file)
 {
     int ret;
     xmlDocPtr doc = NULL;
-    
+
     assert(file);
-    
+
     doc = xmlParseFile(file);
     if (! doc) {
 	lmap_err("cannot parse state file '%s'", file);
@@ -1369,7 +1369,7 @@ lmap_xml_parse_state_string(struct lmap *lmap, const char *string)
 {
     int ret;
     xmlDocPtr doc = NULL;
-    
+
     assert(string);
 
     doc = xmlParseMemory(string, strlen(string));
@@ -1419,7 +1419,7 @@ parse_report(struct lmap *lmap, xmlXPathContextPtr ctx)
 	lmap_err("error in xpath expression '%s'", xpath);
 	return -1;
     }
-    
+
     if (!result->nodesetval || !result->nodesetval->nodeNr) {
 	xmlXPathFreeObject(result);
 	return 0;
@@ -1432,7 +1432,7 @@ parse_report(struct lmap *lmap, xmlXPathContextPtr ctx)
 	    return -1;
 	}
     }
-    
+
     for (i = 0; result->nodesetval && i < result->nodesetval->nodeNr; i++) {
 	xmlNodePtr node = result->nodesetval->nodeTab[i];
 
@@ -1462,7 +1462,7 @@ parse_report(struct lmap *lmap, xmlXPathContextPtr ctx)
 	}
     }
     xmlXPathFreeObject(result);
-    
+
     return 0;
 }
 
@@ -1476,11 +1476,11 @@ parse_value(xmlNodePtr value_node)
     if (! value) {
 	return NULL;
     }
-    
+
     content = xmlNodeGetContent(value_node);
     lmap_value_set_value(value, (char *) content);
     xmlFree(content);
-    
+
     return value;
 }
 
@@ -1494,12 +1494,12 @@ parse_row(xmlNodePtr row_node)
     if (! row) {
 	return NULL;
     }
-    
+
     for (node = xmlFirstElementChild(row_node);
 	 node; node = xmlNextElementSibling(node)) {
 
 	if (node->ns != row_node->ns) continue;
-	
+
 	if (!xmlStrcmp(node->name, BAD_CAST "value")) {
 	    struct value *value = parse_value(node);
 	    lmap_row_add_value(row, value);
@@ -1518,18 +1518,18 @@ parse_table(xmlNodePtr table_node)
     if (! tab) {
 	return NULL;
     }
-    
+
     for (node = xmlFirstElementChild(table_node);
 	 node; node = xmlNextElementSibling(node)) {
 
 	if (node->ns != table_node->ns) continue;
-	
+
 	if (!xmlStrcmp(node->name, BAD_CAST "row")) {
 	    struct row *row = parse_row(node);
 	    lmap_table_add_row(tab, row);
 	}
     }
-    return tab;    
+    return tab;
 }
 
 static struct result *
@@ -1568,10 +1568,10 @@ parse_result(xmlNodePtr result_node)
     if (! res) {
 	return NULL;
     }
-    
+
     for (node = xmlFirstElementChild(result_node);
 	 node; node = xmlNextElementSibling(node)) {
-	
+
 	if (node->ns != result_node->ns) continue;
 
 	if (!xmlStrcmp(node->name, BAD_CAST "option")) {
@@ -1617,7 +1617,7 @@ parse_results(struct lmap *lmap, xmlXPathContextPtr ctx)
     int i;
     xmlXPathObjectPtr result;
     struct result *res;
-    
+
     const char *xpath = "//lmapr:report/lmapr:result";
 
     assert(lmap);
@@ -1669,7 +1669,7 @@ parse_report_doc(struct lmap *lmap, xmlDocPtr doc)
 	ret = -1;
 	goto exit;
     }
-    
+
     for (i = 0; tab[i].parse; i++) {
 	ret = tab[i].parse(lmap, ctx);
 	if (ret != 0) {
@@ -1689,9 +1689,9 @@ lmap_xml_parse_report_file(struct lmap *lmap, const char *file)
 {
     int ret;
     xmlDocPtr doc = NULL;
-    
+
     assert(file);
-    
+
     doc = xmlParseFile(file);
     if (! doc) {
 	lmap_err("cannot parse state file '%s'", file);
@@ -1714,7 +1714,7 @@ lmap_xml_parse_report_string(struct lmap *lmap, const char *string)
 {
     int ret;
     xmlDocPtr doc = NULL;
-    
+
     assert(string);
 
     doc = xmlParseMemory(string, strlen(string));
@@ -1738,7 +1738,7 @@ static void
 render_leaf(xmlNodePtr root, xmlNsPtr ns, char *name, char *content)
 {
     assert(root && ns);
-    
+
     if (name && content) {
 	xmlNewChild(root, ns, BAD_CAST name, BAD_CAST content);
     }
@@ -1748,7 +1748,7 @@ static void
 render_leaf_int32(xmlNodePtr root, xmlNsPtr ns, char *name, int32_t value)
 {
     char buf[32];
-    
+
     snprintf(buf, sizeof(buf), "%" PRIi32, value);
     render_leaf(root, ns, name, buf);
 }
@@ -1757,7 +1757,7 @@ static void
 render_leaf_uint32(xmlNodePtr root, xmlNsPtr ns, char *name, uint32_t value)
 {
     char buf[32];
-    
+
     snprintf(buf, sizeof(buf), "%" PRIu32, value);
     render_leaf(root, ns, name, buf);
 }
@@ -1766,7 +1766,7 @@ static void
 render_leaf_uint64(xmlNodePtr root, xmlNsPtr ns, char *name, uint64_t value)
 {
     char buf[64];
-    
+
     snprintf(buf, sizeof(buf), "%" PRIu64, value);
     render_leaf(root, ns, name, buf);
 }
@@ -1776,7 +1776,7 @@ render_leaf_datetime(xmlNodePtr root, xmlNsPtr ns, char *name, time_t *tp)
 {
     char buf[32];
     struct tm *tmp;
-    
+
     tmp = localtime(tp);
     strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S%z", tmp);
 
@@ -1784,15 +1784,15 @@ render_leaf_datetime(xmlNodePtr root, xmlNsPtr ns, char *name, time_t *tp)
      * Hack to insert the ':' in the timezone offset since strftime()
      * implementations do not generate this separator.
      */
-    
+
     if (strlen(buf) == 24) {
 	buf[25] = buf[24];
 	buf[24] = buf[23];
 	buf[23] = buf[22];
 	buf[22] = ':';
     }
-    
-    render_leaf(root, ns, name, buf); 
+
+    render_leaf(root, ns, name, buf);
 }
 
 static void
@@ -1822,10 +1822,10 @@ render_leaf_months(xmlNodePtr root, xmlNsPtr ns, char *name, uint16_t months)
 	render_leaf(root, ns, name, "*");
 	return;
     }
-	
+
     for (i = 0; tab[i].name; i++) {
 	if (months & tab[i].value) {
-	    render_leaf(root, ns, name, tab[i].name); 
+	    render_leaf(root, ns, name, tab[i].name);
 	}
     }
 }
@@ -1834,7 +1834,7 @@ static void
 render_leaf_days_of_month(xmlNodePtr root, xmlNsPtr ns, char *name, uint32_t days_of_month)
 {
     int i;
-    
+
     if (days_of_month == UINT32_MAX) {
 	render_leaf(root, ns, name, "*");
 	return;
@@ -1842,7 +1842,7 @@ render_leaf_days_of_month(xmlNodePtr root, xmlNsPtr ns, char *name, uint32_t day
 
     for (i = 1; i < 32; i++) {
 	if (days_of_month & (1 << i)) {
-	    render_leaf_int32(root, ns, name, i); 
+	    render_leaf_int32(root, ns, name, i);
 	}
     }
 }
@@ -1869,10 +1869,10 @@ render_leaf_days_of_week(xmlNodePtr root, xmlNsPtr ns, char *name, uint8_t days_
 	render_leaf(root, ns, name, "*");
 	return;
     }
-	
+
     for (i = 0; tab[i].name; i++) {
 	if (days_of_week & tab[i].value) {
-	    render_leaf(root, ns, name, tab[i].name); 
+	    render_leaf(root, ns, name, tab[i].name);
 	}
     }
 }
@@ -1881,7 +1881,7 @@ static void
 render_leaf_hours(xmlNodePtr root, xmlNsPtr ns, char *name, uint32_t hours)
 {
     int i;
-    
+
     if (hours == UINT32_MAX) {
 	render_leaf(root, ns, name, "*");
 	return;
@@ -1889,7 +1889,7 @@ render_leaf_hours(xmlNodePtr root, xmlNsPtr ns, char *name, uint32_t hours)
 
     for (i = 0; i < 24; i++) {
 	if (hours & (1 << i)) {
-	    render_leaf_int32(root, ns, name, i); 
+	    render_leaf_int32(root, ns, name, i);
 	}
     }
 }
@@ -1898,7 +1898,7 @@ static void
 render_leaf_minsecs(xmlNodePtr root, xmlNsPtr ns, char *name, uint64_t minsecs)
 {
     int i;
-    
+
     if (minsecs == UINT64_MAX) {
 	render_leaf(root, ns, name, "*");
 	return;
@@ -1906,7 +1906,7 @@ render_leaf_minsecs(xmlNodePtr root, xmlNsPtr ns, char *name, uint64_t minsecs)
 
     for (i = 0; i < 60; i++) {
 	if (minsecs & (1ull << i)) {
-	    render_leaf_int32(root, ns, name, i); 
+	    render_leaf_int32(root, ns, name, i);
 	}
     }
 }
@@ -1920,7 +1920,7 @@ render_registry(struct registry *registry, xmlNodePtr root, xmlNsPtr ns)
     if (! registry) {
 	return;
     }
-    
+
     node = xmlNewChild(root, ns, BAD_CAST "function", NULL);
     if (! node) {
 	return;
@@ -1940,7 +1940,7 @@ render_option(struct option *option, xmlNodePtr root, xmlNsPtr ns)
     if (! option) {
 	return;
     }
-    
+
     node = xmlNewChild(root, ns, BAD_CAST "option", NULL);
 
     if (! node) {
@@ -2064,13 +2064,13 @@ render_action(struct action *action, xmlNodePtr root, xmlNsPtr ns, int what)
 	if (state) {
 	    render_leaf(node, ns, "state", state);
 	}
-	
+
 	render_leaf_uint64(node, ns, "storage", action->storage);
 	render_leaf_uint32(node, ns, "invocations", action->cnt_invocations);
 	render_leaf_uint32(node, ns, "suppressions", action->cnt_suppressions);
 	render_leaf_uint32(node, ns, "overlaps", action->cnt_overlaps);
 	render_leaf_uint32(node, ns, "failures", action->cnt_failures);
-	
+
 	if (action->last_invocation) {
 	    render_leaf_datetime(node, ns, "last-invocation",
 				 &action->last_invocation);
@@ -2171,13 +2171,13 @@ render_schedules(struct schedule *schedule, xmlNodePtr root, xmlNsPtr ns, int wh
 	    if (state) {
 		render_leaf(node, ns, "state", state);
 	    }
-	    
+
 	    render_leaf_uint64(node, ns, "storage", schedule->storage);
 	    render_leaf_uint32(node, ns, "invocations", schedule->cnt_invocations);
 	    render_leaf_uint32(node, ns, "suppressions", schedule->cnt_suppressions);
 	    render_leaf_uint32(node, ns, "overlaps", schedule->cnt_overlaps);
 	    render_leaf_uint32(node, ns, "failures", schedule->cnt_failures);
-	    
+
 	    if (schedule->last_invocation) {
 		render_leaf_datetime(node, ns, "last-invocation",
 				     &schedule->last_invocation);
@@ -2292,7 +2292,7 @@ render_capabilities(struct capability *capability, xmlNodePtr root, xmlNsPtr ns,
     if (! capability) {
 	return;
     }
-    
+
     if (! (what & RENDER_CONFIG_FALSE)) {
 	return;
     }
@@ -2444,7 +2444,7 @@ render_table(struct table *tab, xmlNodePtr root, xmlNsPtr ns)
 {
     xmlNodePtr node;
     struct row *row;
-    
+
     node = xmlNewChild(root, ns, BAD_CAST "table", NULL);
     if (!node) {
 	return;
@@ -2462,12 +2462,12 @@ render_result(struct result *res, xmlNodePtr root, xmlNsPtr ns)
     struct option *option;
     struct tag *tag;
     struct table *tab;
-    
+
     node = xmlNewChild(root, ns, BAD_CAST "result", NULL);
     if (!node) {
 	return;
     }
-    
+
     render_leaf(node, ns, "schedule", res->schedule);
     render_leaf(node, ns, "action", res->action);
     render_leaf(node, ns, "task", res->task);
@@ -2477,15 +2477,15 @@ render_result(struct result *res, xmlNodePtr root, xmlNsPtr ns)
     for (tag = res->tags; tag; tag = tag->next) {
 	render_leaf(node, ns, "tag", tag->tag);
     }
-    
+
     if (res->event) {
 	render_leaf_datetime(node, ns, "event", &res->start);
     }
-    
+
     if (res->start) {
 	render_leaf_datetime(node, ns, "start", &res->start);
     }
-    
+
     if (res->end) {
 	render_leaf_datetime(node, ns, "end", &res->end);
     }
@@ -2497,7 +2497,7 @@ render_result(struct result *res, xmlNodePtr root, xmlNsPtr ns)
     if (res->flags & LMAP_RESULT_FLAG_STATUS_SET) {
 	render_leaf_int32(node, ns, "status", res->status);
     }
-    
+
     for (tab = res->tables; tab; tab = tab->next) {
 	render_table(tab, node, ns);
     }
@@ -2526,17 +2526,17 @@ render_control(struct lmap *lmap, int what)
 	goto exit;
     }
     xmlDocSetRootElement(doc, root);
-    
+
     ns = xmlNewNs(root, BAD_CAST LMAPC_XML_NAMESPACE, BAD_CAST LMAPC_XML_PREFIX);
     if (ns == NULL) {
 	goto exit;
     }
-    
+
     node = xmlNewChild(root, ns, BAD_CAST "lmap", NULL);
     if (! node) {
 	goto exit;
     }
-    
+
     render_capabilities(lmap->capabilities, node, ns, what);
     render_agent(lmap->agent, node, ns, what);
     render_tasks(lmap->tasks, node, ns, what);
@@ -2624,7 +2624,7 @@ lmap_xml_render_report(struct lmap *lmap)
 	goto exit;
     }
     xmlDocSetRootElement(doc, root);
-    
+
     ns = xmlNewNs(root, BAD_CAST LMAPR_XML_NAMESPACE, BAD_CAST LMAPR_XML_PREFIX);
     if (ns == NULL) {
 	goto exit;

--- a/src/xml-io.c
+++ b/src/xml-io.c
@@ -1230,6 +1230,9 @@ lmap_xml_parse_config_path(struct lmap *lmap, const char *path)
 	if (len < 5) {
 	    continue;
 	}
+	if (dp->d_name[0] == '.') {
+	    continue;
+	}
 	if (strcmp(dp->d_name + len - 4, ".xml")) {
 	    continue;
 	}
@@ -1323,6 +1326,9 @@ lmap_xml_parse_state_path(struct lmap *lmap, const char *path)
     while ((dp = readdir(dfd)) != NULL) {
 	size_t len = strlen(dp->d_name);
 	if (len < 5) {
+	    continue;
+	}
+	if (dp->d_name[0] == '.') {
 	    continue;
 	}
 	if (strcmp(dp->d_name + len - 4, ".xml")) {

--- a/test/check-lmap.c
+++ b/test/check-lmap.c
@@ -39,12 +39,12 @@ static void vlog(int level, const char *func, const char *format, va_list args)
 
 void setup(void)
 {
-  
+
 }
 
 void teardown(void)
 {
-  
+
 }
 
 START_TEST(test_lmap_agent)
@@ -149,7 +149,7 @@ START_TEST(test_lmap_suppression)
     int c;
     struct tag *tag;
     struct supp *supp;
-    
+
     supp = lmap_supp_new();
     ck_assert_int_eq(lmap_supp_valid(NULL, supp), 0);
     ck_assert_str_eq(last_error_msg, "suppression requires a name");
@@ -189,7 +189,7 @@ START_TEST(test_lmap_event)
 {
     const char *date1 = "2016-03-14T07:45:19+01:00";
     const char *date2 = "2016-03-14T07:45:22+01:00";
-    
+
     struct event *event = lmap_event_new();
     ck_assert_int_eq(lmap_event_valid(NULL, event), 0);
     ck_assert_str_eq(last_error_msg, "event requires a type");
@@ -216,7 +216,7 @@ START_TEST(test_lmap_event)
     ck_assert_int_eq(lmap_event_set_end(event, date1), 0);
     ck_assert_int_eq(lmap_event_valid(NULL, event), 0);
     ck_assert_str_eq(last_error_msg, "event 'bang' ends before it starts");
-    
+
     lmap_event_free(event);
 }
 END_TEST
@@ -285,7 +285,7 @@ START_TEST(test_lmap_event_calendar)
     ck_assert_int_eq(lmap_event_add_day_of_week(event, "foo"), -1);
     ck_assert_str_eq(last_error_msg, "illegal day of week value 'foo'");
     ck_assert_int_eq(event->days_of_week, 5);
-    
+
     ck_assert_int_eq(lmap_event_valid(NULL, event), 0);
     ck_assert_str_eq(last_error_msg, "event 'calendar' requires a day of month");
     ck_assert_int_eq(lmap_event_add_day_of_month(event, "1"), 0);
@@ -297,7 +297,7 @@ START_TEST(test_lmap_event_calendar)
     ck_assert_int_eq(lmap_event_add_day_of_month(event, "0"), -1);
     ck_assert_str_eq(last_error_msg, "illegal day of month value '0'");
     ck_assert_int_eq(event->days_of_month, 6);
-    
+
     ck_assert_int_eq(lmap_event_valid(NULL, event), 0);
     ck_assert_str_eq(last_error_msg, "event 'calendar' requires a month");
     ck_assert_int_eq(lmap_event_add_month(event, "february"), 0);
@@ -305,7 +305,7 @@ START_TEST(test_lmap_event_calendar)
     ck_assert_int_eq(lmap_event_add_month(event, "foo"), -1);
     ck_assert_str_eq(last_error_msg, "illegal month value 'foo'");
     ck_assert_int_eq(event->months, 6);
-    
+
     ck_assert_int_eq(lmap_event_valid(NULL, event), 1);
     ck_assert_int_eq(lmap_event_set_timezone_offset(event, "+01:11"), 0);
     ck_assert_int_eq(event->timezone_offset, 1*60+11);
@@ -347,7 +347,7 @@ START_TEST(test_lmap_task)
     struct task *task;
     struct registry *registry;
     struct option *option;
-    
+
     task = lmap_task_new();
     ck_assert_int_eq(lmap_task_valid(NULL, task), 0);
     ck_assert_str_eq(last_error_msg, "task requires a program");
@@ -386,7 +386,7 @@ START_TEST(test_lmap_schedule)
     int c;
     struct tag *tag;
     struct schedule *schedule;
-    
+
     schedule = lmap_schedule_new();
     ck_assert_int_eq(lmap_schedule_valid(NULL, schedule), 0);
     ck_assert_str_eq(last_error_msg, "schedule requires a start event");
@@ -435,7 +435,7 @@ START_TEST(test_lmap_action)
     int c;
     struct tag *tag;
     struct action *action;
-    
+
     action = lmap_action_new();
     ck_assert_int_eq(lmap_action_valid(NULL, action), 0);
     ck_assert_str_eq(last_error_msg, "action requires a task");
@@ -472,7 +472,7 @@ START_TEST(test_lmap_lmap)
     lmap = lmap_new();
     ck_assert_ptr_ne(lmap, NULL);
     ck_assert_int_eq(lmap_valid(lmap), 1);
-        
+
     supp_a = lmap_supp_new();
     supp_b = lmap_supp_new();
     ck_assert_int_eq(lmap_supp_set_name(supp_a, "abcde"), 0);
@@ -515,7 +515,7 @@ START_TEST(test_lmap_row)
     int i;
     char *vals[] = { "foo", "bar", " b a z ", NULL };
     struct value *val;
-    
+
     struct row *row = lmap_row_new();
     for (i = 0; vals[i]; i++) {
 	val = lmap_value_new();
@@ -534,7 +534,7 @@ START_TEST(test_lmap_table)
 {
     struct row *row;
     struct value *val;
-    
+
     struct table *tab = lmap_table_new();
     row = lmap_row_new();
     val = lmap_value_new();
@@ -549,7 +549,7 @@ END_TEST
 START_TEST(test_lmap_result)
 {
     struct result *res;
-    
+
     res = lmap_result_new();
     ck_assert_ptr_ne(res, NULL);
     lmap_result_set_schedule(res, "schedule");
@@ -592,7 +592,7 @@ START_TEST(test_parser_config_agent)
         "</config>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_config_string(lmapa, a), 0);
@@ -647,7 +647,7 @@ START_TEST(test_parser_config_suppressions)
         "</config>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_config_string(lmapa, a), 0);
@@ -728,7 +728,7 @@ START_TEST(test_parser_config_tasks)
         "</config>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_config_string(lmapa, a), 0);
@@ -839,7 +839,7 @@ START_TEST(test_parser_config_events)
         "</config>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_config_string(lmapa, a), 0);
@@ -928,7 +928,7 @@ START_TEST(test_parser_config_events_calendar0)
         "</config>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_config_string(lmapa, a), 0);
@@ -1017,7 +1017,7 @@ START_TEST(test_parser_config_events_calendar1)
         "</config>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_config_string(lmapa, a), 0);
@@ -1112,7 +1112,7 @@ START_TEST(test_parser_config_events_calendar2)
         "</config>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_config_string(lmapa, a), 0);
@@ -1197,7 +1197,7 @@ START_TEST(test_parser_config_events_calendar3)
         "</config>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_config_string(lmapa, a), 0);
@@ -1293,7 +1293,7 @@ START_TEST(test_parser_config_schedules)
         "</config>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_config_string(lmapa, a), 0);
@@ -1382,7 +1382,7 @@ START_TEST(test_parser_config_actions)
         "</config>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_config_string(lmapa, a), 0);
@@ -1474,7 +1474,7 @@ START_TEST(test_parser_config_merge)
         "</config>\n";
     char *d, *e;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_config_string(lmapa, a), 0);
@@ -1523,7 +1523,7 @@ START_TEST(test_parser_state_agent)
         "</data>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_state_string(lmapa, a), 0);
@@ -1573,7 +1573,7 @@ START_TEST(test_parser_state_capabilities)
         "</data>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_state_string(lmapa, a), 0);
@@ -1628,7 +1628,7 @@ START_TEST(test_parser_state_capability_tasks)
         "</data>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_state_string(lmapa, a), 0);
@@ -1689,7 +1689,7 @@ START_TEST(test_parser_state_schedules)
         "</data>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_state_string(lmapa, a), 0);
@@ -1792,7 +1792,7 @@ START_TEST(test_parser_state_actions)
         "</data>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_state_string(lmapa, a), 0);
@@ -1980,7 +1980,7 @@ START_TEST(test_parser_report)
 	"</rpc>\n";
     char *b, *c;
     struct lmap *lmapa = NULL, *lmapb = NULL;
-    
+
     lmapa = lmap_new();
     ck_assert_ptr_ne(lmapa, NULL);
     ck_assert_int_eq(lmap_xml_parse_report_string(lmapa, a), 0);

--- a/test/check-lmapd.c
+++ b/test/check-lmapd.c
@@ -46,12 +46,12 @@ static void alarm_handler(int signum)
 
 void setup(void)
 {
-  
+
 }
 
 void teardown(void)
 {
-  
+
 }
 
 START_TEST(test_lmapd)


### PR DESCRIPTION
This is a respin of #11, which I closed by mistake by an incorrect branch delection.

Functional changes:

-  Do not override CMAKE_BUILD_TYPE
-  Fix a memory leak when rendering JSON reports
-  Skip files starting with a period when reading directories

"Cosmetic" changes:
- Remove stray whitespace in xml-io.c, json-io.c.
- Remove logically unreachable codepaths in lmap_set_capability_path and lmap_set_config_path

"Source correctness" changes (no runtime changes):
- Use the appropriate ACTION constants instead of SCHEDULE constants (but their values are the same)
