### PR TITLE
avoid crash/assert on periodic events with too large a random spread

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -1162,13 +1162,21 @@ lmap_event_valid(struct lmap *lmap, struct event *event)
 	valid = 0;
     }
 
-    if (event->type == LMAP_EVENT_TYPE_PERIODIC
-	&& ! (event->flags & LMAP_EVENT_FLAG_INTERVAL_SET)) {
-	lmap_err("event %s%s%srequires an interval",
-		 event->name ? "'" : "",
-		 event->name ? event->name : "",
-		 event->name ? "' " : "");
-	valid = 0;
+    if (event->type == LMAP_EVENT_TYPE_PERIODIC) {
+	if (!(event->flags & LMAP_EVENT_FLAG_INTERVAL_SET)) {
+	    lmap_err("event %s%s%srequires an interval",
+		     event->name ? "'" : "",
+		     event->name ? event->name : "",
+		     event->name ? "' " : "");
+	    valid = 0;
+	} else if (event->flags & LMAP_EVENT_FLAG_RANDOM_SPREAD_SET
+	    && event->random_spread >= event->interval) {
+	    lmap_err("event %s%s%shas a random spread too large for its interval",
+		     event->name ? "'" : "",
+		     event->name ? event->name : "",
+		     event->name ? "' " : "");
+	    valid = 0;
+	}
     }
     if (event->type == LMAP_EVENT_TYPE_CALENDAR) {
 	if (event->months == 0) {

--- a/src/runner.c
+++ b/src/runner.c
@@ -43,11 +43,15 @@ static void
 event_gaga(struct event *event, struct event **ev,
 	   short what, event_callback_fn func, struct timeval *tv)
 {
-    assert(event && event->lmapd && ev && *ev == NULL);
+    assert(event && event->lmapd && ev);
 
-    *ev = event_new(event->lmapd->base, -1, what, func, event);
-    if (!*ev || event_add(*ev, tv) < 0)  {
-	lmap_err("failed to create/add event for '%s'", event->name);
+    if (!(*ev)) {
+	*ev = event_new(event->lmapd->base, -1, what, func, event);
+	if (!*ev || event_add(*ev, tv) < 0)  {
+	    lmap_err("failed to create/add event for '%s'", event->name);
+	}
+    } else {
+	lmap_err("failed to create/add event for '%s': event already pending, maybe due to too large a random spread?", event->name);
     }
 }
 #endif


### PR DESCRIPTION
On production builds where assert() does nothing, a large random spread can cause event_gaga() to schedule a libevent2 "event->fire_event" past the time where the next libevent2 "event->trigger_event" will run.

When that trigger event runs, it schedules a new fire_event (which might come earlier or later than the one already schedule, depending on the two spreads). libevent2 suports this, and will callback fire_cb (the callback for event->fire_event) twice.  But fire_cb does not, and lmapd will lose track of the situation. Eventually, one fire_cb will run with event->fire_event already set to NULL, and crash.

Also, events could be reordered by this situation.

On debug builds, you hit an assert at runtime when the situation first happens and event_gaga is called with event->fire_event already pending.  The assert() will kill lmapd with a signal, and it will die without any exit cleanups (atexit handlers do not run in this situation).

The proposed fix attempts to turn such a situation (arguably caused by user error, but it can be hard to predict in complex calendar events) into properly logged warnings/errors and recover sanely, so that lmapd isn't stopped and measurements can continue, etc.